### PR TITLE
replace solana-sdk with local shims for solana v3 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - main
+      - v1
     paths:
       - "**.rs"
       - "**.toml"

--- a/.github/workflows/on-program-update.yml
+++ b/.github/workflows/on-program-update.yml
@@ -4,35 +4,41 @@ on:
     types: ['sdk-update']
 
 jobs:
-  on-program-update:
+  check-version:
     runs-on: ubicloud
-    permissions:
-      contents: write
+    outputs:
+      idl_version: ${{ steps.check_version.outputs.idl_version }}
+      skip: ${{ steps.check_version.outputs.skip }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
     - name: Check update version
-      id: check_version  # Added an ID to reference this step
+      id: check_version
       run: |
         VERSION=$(curl -s "https://api.github.com/repos/drift-labs/protocol-v2/tags" | grep -m 1 "name" | cut -d '"' -f 4)
         echo "idl_version=$VERSION" >> $GITHUB_OUTPUT
 
         # Check if version contains beta, alpha, or rc tags
         if echo "$VERSION" | grep -qE "beta|alpha|rc"; then
-          echo "SKIP_PR=true" >> $GITHUB_ENV
-          echo "Skipping PR creation for pre-release version: $VERSION"
+          echo "skip=true" >> $GITHUB_OUTPUT
+          echo "Skipping for pre-release version: $VERSION"
         else
-          echo "SKIP_PR=false" >> $GITHUB_ENV
+          echo "skip=false" >> $GITHUB_OUTPUT
         fi
 
+  bump-v2:
+    needs: check-version
+    if: needs.check-version.outputs.skip == 'false'
+    runs-on: ubicloud
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout master (v2)
+      uses: actions/checkout@v4
+      with:
+        ref: master
+
     - name: Update Cargo.toml
-      if: env.SKIP_PR == 'false'
       run: |
-        # Get idl_version from previous step
-        TAG_VERSION=${{ steps.check_version.outputs.idl_version }}
-        
-        # Strip leading 'v'
+        TAG_VERSION=${{ needs.check-version.outputs.idl_version }}
         CRATE_VERSION=${TAG_VERSION#v}
 
         if ! sed -i 's/^version = ".*"/version = "'$CRATE_VERSION'"/g' Cargo.toml; then
@@ -56,23 +62,78 @@ jobs:
         grep "tag = " Cargo.toml
 
     - name: Cargo check
-      if: env.SKIP_PR == 'false'
       run: |
         rustup install 1.76.0-x86_64-unknown-linux-gnu
         rustup default 1.76.0-x86_64-unknown-linux-gnu
         cargo -V
         cargo check
 
-    - name: Commit changes
-      if: env.SKIP_PR == 'false'
+    - name: Commit and tag
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Configure git
         git config --global user.name "GitHub Actions"
         git config --global user.email "github-actions@github.com"
 
         git add -u
-        git commit -m "chore: bump program to ${{ steps.check_version.outputs.idl_version }}"
-        git tag ${{ steps.check_version.outputs.idl_version }}
+        git commit -m "chore: bump program to ${{ needs.check-version.outputs.idl_version }}"
+        git tag ${{ needs.check-version.outputs.idl_version }}
         git push origin master
+        git push origin ${{ needs.check-version.outputs.idl_version }}
+
+  bump-v1:
+    needs: check-version
+    if: needs.check-version.outputs.skip == 'false'
+    runs-on: ubicloud
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout v1 branch
+      uses: actions/checkout@v4
+      with:
+        ref: v1
+
+    - name: Update Cargo.toml
+      run: |
+        TAG_VERSION=${{ needs.check-version.outputs.idl_version }}
+        CRATE_VERSION=${TAG_VERSION#v}
+
+        if ! sed -i 's/^version = ".*"/version = "'$CRATE_VERSION'"/g' Cargo.toml; then
+          echo "Failed to update version in Cargo.toml"
+          exit 1
+        fi
+
+        if ! sed -i 's/tag = ".*"/tag = "'$TAG_VERSION'"/g' Cargo.toml; then
+          echo "Failed to update tag in Cargo.toml"
+          exit 1
+        fi
+
+        if ! grep "^version = \"$CRATE_VERSION\"" Cargo.toml > /dev/null; then
+          echo "Version update verification failed"
+          exit 1
+        fi
+
+        echo "Successfully updated version in Cargo.toml to $CRATE_VERSION:"
+        grep "^version = " Cargo.toml
+        echo "Successfully updated tag in Cargo.toml to $TAG_VERSION:"
+        grep "tag = " Cargo.toml
+
+    - name: Cargo check
+      run: |
+        rustup install 1.76.0-x86_64-unknown-linux-gnu
+        rustup default 1.76.0-x86_64-unknown-linux-gnu
+        cargo -V
+        cargo check
+
+    - name: Commit and tag
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "github-actions@github.com"
+
+        git add -u
+        git commit -m "chore: bump program to ${{ needs.check-version.outputs.idl_version }} (v1)"
+        git tag "${{ needs.check-version.outputs.idl_version }}-v1"
+        git push origin v1
+        git push origin "${{ needs.check-version.outputs.idl_version }}-v1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Release
 
 on:
-  # manual update
+  # manual update (tag push)
   push:
     tags:
       - "v*"
-  # automated update
+  # automated update (after bump workflow completes)
   workflow_run:
     workflows: ["Bump program version"]
     types:
@@ -16,24 +16,71 @@ jobs:
     runs-on: ubicloud
     # Only run if triggered manually by tag or if the upstream workflow succeeded
     if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
+    outputs:
+      version_line: ${{ steps.detect.outputs.version_line }}
+      cargo_version: ${{ steps.detect.outputs.cargo_version }}
+      tag_name: ${{ steps.detect.outputs.tag_name }}
+      release_name: ${{ steps.detect.outputs.release_name }}
     steps:
-      - name: Check out
+      - name: Detect version line
+        id: detect
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG=${GITHUB_REF#refs/tags/}
+          else
+            # workflow_run trigger: read version from master (v2 default line)
+            echo "Triggered by workflow_run, will read version from Cargo.toml"
+          fi
+
+          if [ -n "$TAG" ]; then
+            if [[ "$TAG" == *-v1 ]]; then
+              echo "version_line=v1" >> $GITHUB_OUTPUT
+              echo "tag_name=$TAG" >> $GITHUB_OUTPUT
+              CARGO_VER=$(echo "$TAG" | sed 's/^v//; s/-v1$//')
+              echo "cargo_version=$CARGO_VER" >> $GITHUB_OUTPUT
+              echo "release_name=$TAG (legacy)" >> $GITHUB_OUTPUT
+            else
+              echo "version_line=v2" >> $GITHUB_OUTPUT
+              echo "tag_name=$TAG" >> $GITHUB_OUTPUT
+              CARGO_VER=$(echo "$TAG" | sed 's/^v//')
+              echo "cargo_version=$CARGO_VER" >> $GITHUB_OUTPUT
+              echo "release_name=$TAG" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      # For workflow_run trigger without a tag: checkout master to read version
+      - name: Check out (workflow_run)
+        if: github.event_name != 'push'
         uses: actions/checkout@v4
+        with:
+          ref: master
 
-      - name: Get version from Cargo.toml
+      - name: Resolve version from Cargo.toml (workflow_run)
+        if: github.event_name != 'push'
         run: |
-          echo "CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f2)" >> $GITHUB_ENV
+          CARGO_VER=$(grep '^version = ' Cargo.toml | cut -d '"' -f2)
+          TAG="v${CARGO_VER}"
+          echo "version_line=v2" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG" >> $GITHUB_OUTPUT
+          echo "cargo_version=$CARGO_VER" >> $GITHUB_OUTPUT
+          echo "release_name=$TAG" >> $GITHUB_OUTPUT
 
-      # For tag trigger: Check that tag matches Cargo.toml version
-      - name: Validate tag match for tag trigger
+      # For tag push trigger: checkout the tagged commit
+      - name: Check out (tag push)
         if: github.event_name == 'push'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Validate tag matches Cargo.toml
         run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-          if [ "$TAG" != "${{ env.CARGO_VERSION }}" ]; then
-            echo "Error: Git tag ($TAG) does not match Cargo.toml version (${{ env.CARGO_VERSION }})"
+          CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f2)
+          EXPECTED="${{ steps.detect.outputs.cargo_version }}"
+          if [ "$CARGO_VERSION" != "$EXPECTED" ]; then
+            echo "Error: Tag version ($EXPECTED) does not match Cargo.toml ($CARGO_VERSION)"
             exit 1
           fi
-          echo "Tag validation successful"
+          echo "Tag validation successful: $CARGO_VERSION"
 
   publish-linux:
     runs-on: ubicloud
@@ -42,6 +89,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release-preflight.outputs.tag_name }}
 
       - name: Install ffi toolchain (1.76.0)
         run: |
@@ -62,6 +111,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release-preflight.outputs.tag_name }}
 
       - name: Install ffi toolchain (1.76.0)
         run: |
@@ -84,10 +135,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
-
-      - name: Get version from Cargo.toml
-        run: |
-          echo "CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d '"' -f2)" >> $GITHUB_ENV
+        with:
+          ref: ${{ needs.create-release-preflight.outputs.tag_name }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -95,21 +144,23 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          name: v${{ env.CARGO_VERSION }}
+          name: ${{ needs.create-release-preflight.outputs.release_name }}
           files: |
             libdrift_ffi_sys.so/libdrift_ffi_sys.so
             libdrift_ffi_sys.dylib/libdrift_ffi_sys.dylib
           generate_release_notes: true
-          tag_name: v${{ env.CARGO_VERSION }}
+          tag_name: ${{ needs.create-release-preflight.outputs.tag_name }}
 
       - name: Emit dispatch event
         run: |
-          VERSION="v${{ env.CARGO_VERSION }}"
+          VERSION="v${{ needs.create-release-preflight.outputs.cargo_version }}"
+          VERSION_LINE="${{ needs.create-release-preflight.outputs.version_line }}"
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${{ secrets.GH_PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/drift-labs/drift-rs/dispatches" \
             -d "{\"event_type\": \"libdrift-update\", \"client_payload\": {
-              \"version\": \"$VERSION\"
+              \"version\": \"$VERSION\",
+              \"version_line\": \"$VERSION_LINE\"
             }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,6 @@ dependencies = [
  "anchor-lang",
  "drift",
  "fxhash",
- "solana-sdk",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ drift-program = { package = "drift", git = "https://github.com/drift-labs/protoc
     "mainnet-beta", "drift-rs"
 ] }
 fxhash = "0.2.1"
-solana-sdk = { version = "1.16.*" }

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -9,11 +9,7 @@ use abi_stable::std_types::{
 };
 use anchor_lang::{
     prelude::{AccountInfo, AccountLoader},
-    solana_program::{
-        account_info::IntoAccountInfo,
-        clock::Clock,
-        pubkey::Pubkey,
-    },
+    solana_program::{account_info::IntoAccountInfo, clock::Clock, pubkey::Pubkey},
 };
 use drift_program::{
     controller::{position::PositionDirection, repeg::_update_amm},

--- a/src/exports.rs
+++ b/src/exports.rs
@@ -7,7 +7,14 @@ use abi_stable::std_types::{
     ROption,
     RResult::{RErr, ROk},
 };
-use anchor_lang::prelude::{AccountInfo, AccountLoader};
+use anchor_lang::{
+    prelude::{AccountInfo, AccountLoader},
+    solana_program::{
+        account_info::IntoAccountInfo,
+        clock::Clock,
+        pubkey::Pubkey,
+    },
+};
 use drift_program::{
     controller::{position::PositionDirection, repeg::_update_amm},
     math::{self, amm::calculate_amm_available_liquidity, margin::MarginRequirementType},
@@ -25,12 +32,8 @@ use drift_program::{
         user::{Order, PerpPosition, SpotPosition, User},
     },
 };
-use solana_sdk::{
-    account::Account,
-    account_info::IntoAccountInfo,
-    clock::{Clock, Slot},
-    pubkey::Pubkey,
-};
+
+use crate::shims::{Account, Slot};
 
 use crate::{
     margin::IncrementalMarginCalculation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! Drift program FFI exports
 mod exports;
 pub mod margin;
+pub mod shims;
 pub mod types;

--- a/src/margin.rs
+++ b/src/margin.rs
@@ -954,7 +954,7 @@ mod tests {
             spot_market::{AssetTier, SpotBalanceType, SpotMarket},
         },
     };
-    use solana_sdk::pubkey::Pubkey;
+    use anchor_lang::solana_program::pubkey::Pubkey;
 
     use super::*;
 

--- a/src/margin.rs
+++ b/src/margin.rs
@@ -942,6 +942,7 @@ pub fn can_be_liquidated(calculation: &SimplifiedMarginCalculation) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use anchor_lang::solana_program::pubkey::Pubkey;
     use drift_program::{
         math::constants::{
             AMM_RESERVE_PRECISION, BASE_PRECISION_I64, MAX_CONCENTRATION_COEFFICIENT,
@@ -954,7 +955,6 @@ mod tests {
             spot_market::{AssetTier, SpotBalanceType, SpotMarket},
         },
     };
-    use anchor_lang::solana_program::pubkey::Pubkey;
 
     use super::*;
 

--- a/src/shims.rs
+++ b/src/shims.rs
@@ -1,0 +1,52 @@
+//! Solana type shims for v1.16/v3 cross-compatibility.
+//!
+//! These types replace direct `solana-sdk` imports, providing a client-side
+//! `Account` struct that is ABI-compatible with both solana-sdk 1.16 and
+//! solana-account v3. Fields removed or deprecated in v3 (e.g. `rent_epoch`)
+//! use default values.
+//!
+//! All types use `#[repr(C)]` to guarantee a stable field layout across
+//! different Rust compiler versions (the FFI dylib and the caller may be
+//! compiled with different toolchains).
+
+use anchor_lang::solana_program::{
+    account_info::{Account as AccountTrait, AccountInfo, IntoAccountInfo},
+    clock::Epoch,
+    pubkey::Pubkey,
+};
+
+/// Client-side account representation.
+///
+/// Layout-identical to both `solana_sdk::account::Account` (v1.16) and
+/// `solana_account::Account` (v3), but with `#[repr(C)]` to guarantee
+/// consistent field ordering across compiler versions.
+///
+/// `rent_epoch` is retained for compatibility but defaults to `0` matching
+/// the v3 convention.
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Account {
+    pub lamports: u64,
+    pub data: Vec<u8>,
+    pub owner: Pubkey,
+    pub executable: bool,
+    /// Deprecated in solana v3; retained for ABI layout compatibility.
+    pub rent_epoch: Epoch,
+}
+
+/// Implements solana-program's `Account` trait so that the blanket
+/// `IntoAccountInfo for &mut (Pubkey, Account)` impl works automatically.
+impl AccountTrait for Account {
+    fn get(&mut self) -> (&mut u64, &mut [u8], &Pubkey, bool, Epoch) {
+        (
+            &mut self.lamports,
+            &mut self.data,
+            &self.owner,
+            self.executable,
+            self.rent_epoch,
+        )
+    }
+}
+
+/// Convenience alias — `Slot` is always `u64`.
+pub type Slot = u64;

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,10 @@
 use std::collections::HashMap;
 
 use abi_stable::std_types::RResult;
+use anchor_lang::solana_program::{
+    account_info::{Account as _, AccountInfo, IntoAccountInfo},
+    pubkey::Pubkey,
+};
 use drift_program::{
     controller::position::PositionDirection,
     math::{margin::MarginRequirementType, oracle::OracleValidity},
@@ -14,10 +18,6 @@ use drift_program::{
         state::OracleGuardRails,
         user::{MarketType, OrderTriggerCondition, OrderType},
     },
-};
-use anchor_lang::solana_program::{
-    account_info::{Account as _, AccountInfo, IntoAccountInfo},
-    pubkey::Pubkey,
 };
 use fxhash::FxBuildHasher;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,13 +15,13 @@ use drift_program::{
         user::{MarketType, OrderTriggerCondition, OrderType},
     },
 };
-use fxhash::FxBuildHasher;
-use solana_sdk::{
-    account::Account,
+use anchor_lang::solana_program::{
     account_info::{Account as _, AccountInfo, IntoAccountInfo},
-    clock::Slot,
     pubkey::Pubkey,
 };
+use fxhash::FxBuildHasher;
+
+use crate::shims::{Account, Slot};
 
 #[repr(C)]
 #[derive(Debug)]


### PR DESCRIPTION
introduce a shims module with a #[repr(C)] Account struct and Slot alias. Types are sourced from anchor-lang's solana-program re-export instead.

This allows drift-rs to pass solana v3 Account data across the FFI boundary with a guaranteed stable field layout regardless of compiler version.

companion https://github.com/drift-labs/drift-rs/pull/310