### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.github/workflows/manual-program-update.yml
+++ b/.github/workflows/manual-program-update.yml
@@ -13,5 +13,5 @@ jobs:
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: token ${{ secrets.GH_PAT }}" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        https://api.github.com/repos/drift-labs/drift-ffi-sys/dispatches \
+        https://api.github.com/repos/velocity-exchange/drift-ffi-sys/dispatches \
         -d '{"event_type":"sdk-update","client_payload":{"version":"latest"}}'

--- a/.github/workflows/on-program-update.yml
+++ b/.github/workflows/on-program-update.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Check update version
       id: check_version
       run: |
-        VERSION=$(curl -s "https://api.github.com/repos/drift-labs/protocol-v2/tags" | grep -m 1 "name" | cut -d '"' -f 4)
+        VERSION=$(curl -s "https://api.github.com/repos/velocity-exchange/protocol-v2/tags" | grep -m 1 "name" | cut -d '"' -f 4)
         echo "idl_version=$VERSION" >> $GITHUB_OUTPUT
 
         # Check if version contains beta, alpha, or rc tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token ${{ secrets.GH_PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/drift-labs/drift-rs/dispatches" \
+            "https://api.github.com/repos/velocity-exchange/drift-rs/dispatches" \
             -d "{\"event_type\": \"libdrift-update\", \"client_payload\": {
               \"version\": \"$VERSION\",
               \"version_line\": \"$VERSION_LINE\"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ dependencies = [
 [[package]]
 name = "drift"
 version = "2.162.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "drift-macros"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/drift-macros.git?rev=c57d87#c57d87e073d13d43f4d1fb09fe6822915a4ccc11"
+source = "git+https://github.com/velocity-exchange/drift-macros.git?rev=c57d87#c57d87e073d13d43f4d1fb09fe6822915a4ccc11"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1818,7 +1818,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openbook-v2-light"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.3",
@@ -1881,7 +1881,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 [[package]]
 name = "phoenix-v1"
 version = "0.2.4"
-source = "git+https://github.com/drift-labs/phoenix-v1?rev=7703c5#7703c50cf92f2bb321dcd1e2824e1c041135ec5c"
+source = "git+https://github.com/velocity-exchange/phoenix-v1?rev=7703c5#7703c50cf92f2bb321dcd1e2824e1c041135ec5c"
 dependencies = [
  "borsh 0.10.3",
  "bytemuck",
@@ -1985,7 +1985,7 @@ checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 [[package]]
 name = "pyth-solana-receiver-sdk"
 version = "0.3.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
 dependencies = [
  "anchor-lang",
  "hex",
@@ -1996,7 +1996,7 @@ dependencies = [
 [[package]]
 name = "pyth_lazer"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
 dependencies = [
  "anchor-lang",
  "anyhow",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "pythnet-sdk"
 version = "2.1.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2996,7 +2996,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "switchboard"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
 dependencies = [
  "anchor-lang",
 ]
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "switchboard-on-demand"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.162.0#0d35029d780b5faf8b80fce84053e862802badc1"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 abi_stable = { version = "0.11", default-features = false }
 anchor-lang = "0.29.0"
-drift-program = { package = "drift", git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.162.0", features = [
+drift-program = { package = "drift", git = "https://github.com/velocity-exchange/protocol-v2.git", tag = "v2.162.0", features = [
     "mainnet-beta", "drift-rs"
 ] }
 fxhash = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Goals:
 
 ### Prebuilt
 
-Download latest [release libs](https://github.com/drift-labs/drift-ffi-sys/releases), unzip and link/copy to `/usr/lib` (linux) or `/usr/local/lib` (mac)
+Download latest [release libs](https://github.com/velocity-exchange/drift-ffi-sys/releases), unzip and link/copy to `/usr/lib` (linux) or `/usr/local/lib` (mac)
 
 ### from Source
 ```shell
@@ -38,7 +38,7 @@ CI job does this automatically but occasionally fails due to breaking changes.
 2) update `tag = "v2.140.0"` to the latest version in `Cargo.toml`
 
 ```Cargo.toml
-drift-program = { package = "drift", git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.140.0", features = [
+drift-program = { package = "drift", git = "https://github.com/velocity-exchange/protocol-v2.git", tag = "v2.140.0", features = [
     "mainnet-beta", "drift-rs"
 ] }
 ```


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.

## URL forms changed

- `github.com/drift-labs/drift-ffi-sys` → `github.com/velocity-exchange/drift-ffi-sys` (1 occurrence — CI dispatch URL in `manual-program-update.yml`)
- `github.com/drift-labs/protocol-v2` → `github.com/velocity-exchange/protocol-v2` (7 occurrences — `on-program-update.yml`, `Cargo.toml` dep, `Cargo.lock` resolved sources, `README.md` example snippet)
- `github.com/drift-labs/drift-rs` → `github.com/velocity-exchange/drift-rs` (1 occurrence — CI dispatch URL in `release.yml`)
- `github.com/drift-labs/drift-macros` → `github.com/velocity-exchange/drift-macros` (1 occurrence — `Cargo.lock` resolved source)
- `github.com/drift-labs/phoenix-v1` → `github.com/velocity-exchange/phoenix-v1` (1 occurrence — `Cargo.lock` resolved source; see note below)
- `github.com/drift-labs/pyth-crosschain` → `github.com/velocity-exchange/pyth-crosschain` (2 occurrences — `Cargo.lock` resolved sources; see note below)

**Total: 15 substitutions across 6 files.**

## Skipped (upstream-Drift historical refs)

None — all `drift-labs` references in this repo point to the org's own repos (this repo, protocol-v2, drift-rs, drift-macros) or to dependency forks hosted under the org (phoenix-v1, pyth-crosschain).

## Notes for reviewer

- `phoenix-v1` and `pyth-crosschain` in `Cargo.lock` are dependency forks originally from external projects (Ellipsis Labs / Pyth Network) that were re-hosted under `drift-labs`. Their Cargo.lock entries have been rewritten to `velocity-exchange/...` on the assumption they will be re-hosted under the new org. If those repos are NOT being transferred/re-forked under `velocity-exchange`, revert those two `Cargo.lock` entries and update `Cargo.toml` (and `Cargo.lock` via `cargo update`) to point at the canonical upstream sources instead.
- `Cargo.lock` was updated in-place to keep the file consistent with the rewritten `Cargo.toml`. The lock file hashes and commit SHAs are unchanged — Cargo will re-verify them on first build. If the repos are moved rather than re-created, the existing SHAs will still resolve.